### PR TITLE
fix(RdFullSlide): follow-rule cannot read next slide when viewerport height too short

### DIFF
--- a/components/report/follow-rule/components/RdFullSlides.vue
+++ b/components/report/follow-rule/components/RdFullSlides.vue
@@ -157,7 +157,7 @@ export default {
 .full-slide {
   position: relative;
   background: #feeade;
-  max-width: 712px;
+  width: var(--slide-width);
   margin: 0 auto;
   overflow: hidden;
 


### PR DESCRIPTION
### 描述
- 解決跟騷法專題螢幕高度過窄時，主互動區會看到下一章的問題。