### PR TITLE
fix: cannot render infogram embedded script

### DIFF
--- a/components/shared/RdEmbeddedCode.vue
+++ b/components/shared/RdEmbeddedCode.vue
@@ -63,6 +63,7 @@ export default {
         const src = item.attribs?.src ?? ''
         const s = document.createElement('script')
         s.setAttribute('src', src)
+        s.text = item.text || ''
         document.body.appendChild(s)
       })
     },


### PR DESCRIPTION
### 問題描述
infogram 的 embedded code 不是用 `<script src=""></script>`，而是用 `<script> function ... </script>` 的方式載入內容。
此 PR 修正了只處理 `script.src`，而沒有處理 `script.text` 的問題。

### Infogram embedd code 範例
```
<div class="infogram-embed" data-id="5649d0a9-2db1-4d10-be74-458ca1d9b4c9" data-type="interactive" data-title="uk02"></div><script>!function(e,i,n,s){var t="InfogramEmbeds",d=e.getElementsByTagName("script")[0];if(window[t]&&window[t].initialized)window[t].process&&window[t].process();else if(!e.getElementById(n)){var o=e.createElement("script");o.async=1,o.id=n,o.src="https://e.infogram.com/js/dist/embed-loader-min.js",d.parentNode.insertBefore(o,d)}}(document,0,"infogram-async");</script><div style="padding:8px 0;font-family:Arial!important;font-size:13px!important;line-height:15px!important;text-align:center;border-top:1px solid #dadada;margin:0 30px"><a href="https://infogram.com/5649d0a9-2db1-4d10-be74-458ca1d9b4c9" style="color:#989898!important;text-decoration:none!important;" target="_blank">uk02</a><br><a href="https://infogram.com/" style="color:#989898!important;text-decoration:none!important;" target="_blank" rel="nofollow">Infogram</a></div>
```