### PR TITLE
refactor: add special rule to render custom credits

### DIFF
--- a/components/app/Frame/RdFrame.vue
+++ b/components/app/Frame/RdFrame.vue
@@ -247,10 +247,20 @@ export default {
         )
         .map((key) => {
           return key === 'otherByline' && typeof this.post[key] === 'string'
-            ? {
-                key,
-                data: this.post[key].split('、').map((d) => ({ name: d })),
-              }
+            ? this.post?.[key].startsWith('*')
+              ? // workaround: 特殊頁面需要客製化 credit 清單，在 cms Post 作者（其他）欄位中以星號開頭來啟用，以全形的'／'來產生換行效果
+                {
+                  key,
+                  data: this.post[key]
+                    .slice(1)
+                    .split('／')
+                    .map((d) => ({ name: d })),
+                  special: true,
+                }
+              : {
+                  key,
+                  data: this.post[key].split('、').map((d) => ({ name: d })),
+                }
             : {
                 key,
                 data: this.post[key],

--- a/components/app/Frame/RdFrameCredit.vue
+++ b/components/app/Frame/RdFrameCredit.vue
@@ -3,10 +3,19 @@
     <div class="credit-list">
       <ul>
         <li v-for="item in formatedList" :key="item.key">
-          <div class="title">{{ item.key }}：</div>
-          <span v-for="(person, i) in item.data" :key="i">
-            {{ i === 0 ? '' : '、' }}{{ person.name }}
-          </span>
+          <div v-if="!item.special" class="normal-item">
+            <div class="title">{{ item.key }}：</div>
+            <span v-for="(person, i) in item.data" :key="i">
+              {{ i === 0 ? '' : '、' }}{{ person.name }}
+            </span>
+          </div>
+          <!-- workaround: 特殊頁面需要客製化 credit 清單，在 cms Post 作者（其他）欄位中以星號開頭來啟用，以全形的'／'來產生換行效果 -->
+          <div v-else>
+            <div class="title">{{ item.key }}：</div>
+            <div v-for="(person, i) in item.data" :key="i">
+              {{ person.name }}
+            </div>
+          </div>
         </li>
       </ul>
     </div>
@@ -70,6 +79,7 @@ export default {
       return this.credits?.map((item) => ({
         key: CONTACT_MAPPING[item.key],
         data: item.data,
+        special: item.special,
       }))
     },
   },
@@ -147,8 +157,13 @@ export default {
       @include media-breakpoint-up(md) {
         font-size: 16px;
       }
+      .normal-item {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-wrap: wrap;
+      }
       .title {
-        display: block;
         color: rgba(0, 9, 40, 0.66);
       }
     }


### PR DESCRIPTION
# Notable change

在Post欄位中的作者相關欄位不敷使用的情況下，透過在作者(其他)欄位中填寫星號(*)開頭，並以全型'／'來產生換行效果。

ex: 字串：
`*監製：簡信昌／製作人：李又如、張蘊方、王薏晴／採訪與腳本：劉雅婷／插畫：EDO／設計：EDO、曾立宇／3D 建模：洪詩宸／VR 製作：李又如／網頁工程：李法賢、李依軒／聲音演員：梓朗、德、心／部分聲音素材：香港記者提供／特別感謝：謝佩潁、陳詠雙／贊助：International News Media Association`

![image](https://user-images.githubusercontent.com/104348940/225852863-37f4873b-84bb-474d-a75a-1e82353920a9.png)
